### PR TITLE
Revise README with PyPose installation details

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Then you can install instantsfm locally by running:
 ```bash
 pip install -e .
 ```
+Install PyPose from the bae branch:
+```bash
+pip install git+https://github.com/pypose/pypose.git@bae
+```
 Install bae by running:
 ```bash
 pip install git+ssh://git@github.com/zitongzhan/bae.git
@@ -128,4 +132,5 @@ Want to apply several modifications to config files while keeping the original o
 
 
 **Acknowledgments**: We thank the following great works [COLMAP](https://github.com/colmap/colmap), [GLOMAP](https://github.com/colmap/glomap), [VGGT](https://github.com/facebookresearch/vggt), [VGGSfM](https://github.com/facebookresearch/vggsfm) for their code. We would like to thank Linfei Pan for the help.
+
 


### PR DESCRIPTION
Hi, it might be better to add `PyPose` installation guide here, since it will not be installed with `bae` automatically. I encountered `pypose` import error and just `pip install pypose` which results in another error (zitongzhan/bae#1), then I found that actually a custom `bae` branch of it is needed.