### PR TITLE
Improve VGC convergence

### DIFF
--- a/instantsfm/processors/view_graph_calibration.py
+++ b/instantsfm/processors/view_graph_calibration.py
@@ -1,28 +1,184 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
 import numpy as np
+import pyceres
 import torch
 import tqdm
-import pyceres
+from scipy.optimize import minimize_scalar
 
 from instantsfm.scene.defs import ConfigurationType, ViewGraph
-from instantsfm.utils.cost_function import FetzerFocalLengthCostFunction, FetzerFocalLengthSameCameraCostFunction, fetzer_ds, fetzer_cost
+from instantsfm.utils.cost_function import (
+    FetzerFocalLengthCostFunction,
+    FetzerFocalLengthSameCameraCostFunction,
+    fetzer_cost,
+    fetzer_ds,
+)
 from instantsfm.utils.optimization_models import FetzerCalibrationModel
 
 # used by torch LM
-import torch
-from torch import nn
 import pypose as pp
 from pypose.optim.kernel import Cauchy
 from bae.utils.pysolvers import PCG
 from bae.optim import LM
-from bae.autograd.function import TrackingTensor
 
-def SolveViewGraphCalibration(view_graph:ViewGraph, cameras, images, VIEW_GRAPH_CALIBRATOR_OPTIONS):
-    valid_image_pairs = {pair_id: image_pair for pair_id, image_pair in view_graph.image_pairs.items()
-                         if image_pair.is_valid and image_pair.config in [ConfigurationType.CALIBRATED, ConfigurationType.UNCALIBRATED]}
-    if len(valid_image_pairs) == 0:
+
+DEFAULT_MIN_CALIBRATED_PAIR_RATIO = 0.5
+
+
+@dataclass(frozen=True)
+class ViewGraphCalibrationInput:
+    pair_id: Tuple[int, int]
+    camera_id1: int
+    camera_id2: int
+    F: np.ndarray
+    d01: np.ndarray
+    d12: np.ndarray
+
+
+@dataclass
+class ViewGraphCalibrationResult:
+    success: bool
+    initial_focals: np.ndarray
+    optimized_focals: np.ndarray
+    calibration_errors_sq: Dict[Tuple[int, int], float]
+    num_rejected_cameras: int
+    num_invalid_pairs: int
+    raw_loss: float
+    robust_loss: float
+
+
+def _fundamental_from_essential(E: np.ndarray, camera1, camera2) -> np.ndarray:
+    K1_inv = np.linalg.inv(camera1.get_K())
+    K2_inv_t = np.linalg.inv(camera2.get_K()).T
+    return K2_inv_t @ E @ K1_inv
+
+
+
+def _essential_from_fundamental(F: np.ndarray, camera1, camera2) -> np.ndarray:
+    return camera2.get_K().T @ F @ camera1.get_K()
+
+
+
+def _compute_pair_residuals(
+    calibration_input: ViewGraphCalibrationInput,
+    focal_length1: float,
+    focal_length2: float,
+):
+    fi_sq = focal_length1 * focal_length1
+    fj_sq = focal_length2 * focal_length2
+
+    di = fj_sq * calibration_input.d01[0] + calibration_input.d01[1]
+    dj = fi_sq * calibration_input.d12[0] + calibration_input.d12[2]
+    if di == 0:
+        di = 1e-6
+    if dj == 0:
+        dj = 1e-6
+
+    k0_01 = -(fj_sq * calibration_input.d01[2] + calibration_input.d01[3]) / di
+    k1_12 = -(fi_sq * calibration_input.d12[1] + calibration_input.d12[3]) / dj
+
+    residual0 = (fi_sq - k0_01) / fi_sq
+    residual1 = (fj_sq - k1_12) / fj_sq
+    return residual0, residual1
+
+
+def _compute_pair_error_sq(
+    calibration_input: ViewGraphCalibrationInput,
+    focal_length1: float,
+    focal_length2: float,
+) -> float:
+    residual0, residual1 = _compute_pair_residuals(
+        calibration_input,
+        focal_length1,
+        focal_length2,
+    )
+    return residual0 * residual0 + residual1 * residual1
+
+
+
+def BuildViewGraphCalibrationInputs(view_graph: ViewGraph, cameras, images):
+    inputs = []
+    for pair_id, image_pair in view_graph.image_pairs.items():
+        if not image_pair.is_valid:
+            continue
+        if image_pair.config not in (ConfigurationType.CALIBRATED, ConfigurationType.UNCALIBRATED):
+            continue
+
+        image1 = images[image_pair.image_id1]
+        image2 = images[image_pair.image_id2]
+        camera1 = cameras[image1.cam_id]
+        camera2 = cameras[image2.cam_id]
+
+        F = image_pair.F
+        if image_pair.config == ConfigurationType.CALIBRATED and image_pair.E is not None and np.any(image_pair.E):
+            F = _fundamental_from_essential(image_pair.E, camera1, camera2)
+            image_pair.F = F
+
+        K0 = np.array(
+            [[1.0, 0.0, camera1.principal_point[0]], [0.0, 1.0, camera1.principal_point[1]], [0.0, 0.0, 1.0]],
+            dtype=np.float64,
+        )
+        K1 = np.array(
+            [[1.0, 0.0, camera2.principal_point[0]], [0.0, 1.0, camera2.principal_point[1]], [0.0, 0.0, 1.0]],
+            dtype=np.float64,
+        )
+        ds = fetzer_ds(K1.T @ F @ K0)
+        inputs.append(
+            ViewGraphCalibrationInput(
+                pair_id=pair_id,
+                camera_id1=image1.cam_id,
+                camera_id2=image2.cam_id,
+                F=F,
+                d01=np.asarray(ds[0], dtype=np.float64),
+                d12=np.asarray(ds[2], dtype=np.float64),
+            )
+        )
+
+    return inputs
+
+
+
+def EvaluateViewGraphCalibrationObjective(calibration_inputs, cameras, loss_scale: float):
+    raw_loss = 0.0
+    robust_loss = 0.0
+    loss_scale_sq = loss_scale * loss_scale
+
+    for calibration_input in calibration_inputs:
+        focal_length1 = float(np.mean(cameras[calibration_input.camera_id1].focal_length))
+        focal_length2 = float(np.mean(cameras[calibration_input.camera_id2].focal_length))
+        error_sq = _compute_pair_error_sq(calibration_input, focal_length1, focal_length2)
+        raw_loss += error_sq
+        robust_loss += 0.5 * loss_scale_sq * np.log1p(error_sq / loss_scale_sq)
+
+    return raw_loss, robust_loss
+
+
+
+def SolveViewGraphCalibration(view_graph: ViewGraph, cameras, images, VIEW_GRAPH_CALIBRATOR_OPTIONS):
+    calibration_inputs = BuildViewGraphCalibrationInputs(view_graph, cameras, images)
+    initial_focals = np.array([np.mean(cam.focal_length) for cam in cameras], dtype=np.float64)
+    optimized_focals = initial_focals.copy()
+
+    if len(calibration_inputs) == 0:
         print('No valid image pairs for view graph calibration; skipping.')
-        return
-    focals = np.array([np.mean(cam.focal_length) for cam in cameras])
+        raw_loss, robust_loss = EvaluateViewGraphCalibrationObjective(
+            calibration_inputs,
+            cameras,
+            VIEW_GRAPH_CALIBRATOR_OPTIONS['thres_loss_function'],
+        )
+        return ViewGraphCalibrationResult(
+            success=True,
+            initial_focals=initial_focals,
+            optimized_focals=optimized_focals,
+            calibration_errors_sq={},
+            num_rejected_cameras=0,
+            num_invalid_pairs=0,
+            raw_loss=raw_loss,
+            robust_loss=robust_loss,
+        )
 
     problem = pyceres.Problem()
     options = pyceres.SolverOptions()
@@ -31,61 +187,168 @@ def SolveViewGraphCalibration(view_graph:ViewGraph, cameras, images, VIEW_GRAPH_
         options.linear_solver_type = pyceres.LinearSolverType.DENSE_NORMAL_CHOLESKY
     else:
         options.linear_solver_type = pyceres.LinearSolverType.SPARSE_NORMAL_CHOLESKY
-    
-    bounded_cam_ids = set()
-    for image_pair in valid_image_pairs.values():
-        image1, image2 = images[image_pair.image_id1], images[image_pair.image_id2]
-        cam1, cam2 = cameras[image1.cam_id], cameras[image2.cam_id]
-        cam_id1, cam_id2 = image1.cam_id, image2.cam_id
+
+    parameter_blocks = {}
+    for calibration_input in calibration_inputs:
+        cam_id1 = calibration_input.camera_id1
+        cam_id2 = calibration_input.camera_id2
+        parameter_blocks.setdefault(cam_id1, optimized_focals[cam_id1:cam_id1 + 1])
+        parameter_blocks.setdefault(cam_id2, optimized_focals[cam_id2:cam_id2 + 1])
+
         if cam_id1 == cam_id2:
-            cost_function = FetzerFocalLengthSameCameraCostFunction(image_pair.F, cam1.principal_point)
-            problem.add_residual_block(cost_function, loss_function, [focals[cam_id1:cam_id1+1]])
+            cost_function = FetzerFocalLengthSameCameraCostFunction(
+                calibration_input.F,
+                cameras[cam_id1].principal_point,
+            )
+            problem.add_residual_block(cost_function, loss_function, [parameter_blocks[cam_id1]])
         else:
-            cost_function = FetzerFocalLengthCostFunction(image_pair.F, cam1.principal_point, cam2.principal_point)
-            problem.add_residual_block(cost_function, loss_function, [focals[cam_id1:cam_id1+1], focals[cam_id2:cam_id2+1]])
-        if cam_id1 not in bounded_cam_ids:
-            problem.set_parameter_lower_bound(focals[cam_id1:cam_id1+1], 0, 1e-3)
-            bounded_cam_ids.add(cam_id1)
-        if cam_id2 not in bounded_cam_ids:
-            problem.set_parameter_lower_bound(focals[cam_id2:cam_id2+1], 0, 1e-3)
-            bounded_cam_ids.add(cam_id2)
+            cost_function = FetzerFocalLengthCostFunction(
+                calibration_input.F,
+                cameras[cam_id1].principal_point,
+                cameras[cam_id2].principal_point,
+            )
+            problem.add_residual_block(
+                cost_function,
+                loss_function,
+                [parameter_blocks[cam_id1], parameter_blocks[cam_id2]],
+            )
+
+    num_variable_cameras = 0
+    for cam_id, parameter_block in parameter_blocks.items():
+        problem.set_parameter_lower_bound(parameter_block, 0, 1e-3)
+        if cameras[cam_id].has_prior_focal_length:
+            problem.set_parameter_block_constant(parameter_block)
+        else:
+            num_variable_cameras += 1
 
     options.max_num_iterations = VIEW_GRAPH_CALIBRATOR_OPTIONS['max_num_iterations']
     options.function_tolerance = VIEW_GRAPH_CALIBRATOR_OPTIONS['function_tolerance']
-    # options.minimizer_progress_to_stdout = True
 
-    summary = pyceres.SolverSummary()
-    pyceres.solve(options, problem, summary)
-    print(summary.BriefReport())
+    success = True
+    if num_variable_cameras == 0:
+        print('All connected cameras have prior focal length, skipping view graph calibration')
+    else:
+        variable_camera_ids = sorted(
+            cam_id for cam_id in parameter_blocks if not cameras[cam_id].has_prior_focal_length
+        )
+        if len(variable_camera_ids) == 1:
+            variable_cam_id = variable_camera_ids[0]
+            initial_focal = initial_focals[variable_cam_id]
+            loss_scale_sq = VIEW_GRAPH_CALIBRATOR_OPTIONS['thres_loss_function'] ** 2
 
-    # copy back results
+            def scalar_objective(focal):
+                total = 0.0
+                for calibration_input in calibration_inputs:
+                    focal1 = initial_focals[calibration_input.camera_id1]
+                    focal2 = initial_focals[calibration_input.camera_id2]
+                    if calibration_input.camera_id1 == variable_cam_id:
+                        focal1 = focal
+                    if calibration_input.camera_id2 == variable_cam_id:
+                        focal2 = focal
+                    error_sq = _compute_pair_error_sq(
+                        calibration_input,
+                        float(focal1),
+                        float(focal2),
+                    )
+                    total += 0.5 * loss_scale_sq * np.log1p(error_sq / loss_scale_sq)
+                return total
+
+            upper_bound = max(
+                1.0,
+                initial_focal * VIEW_GRAPH_CALIBRATOR_OPTIONS['thres_higher_ratio'],
+            )
+            scipy_result = minimize_scalar(
+                scalar_objective,
+                bounds=(1e-3, upper_bound),
+                method='bounded',
+                options={'xatol': VIEW_GRAPH_CALIBRATOR_OPTIONS['function_tolerance'], 'maxiter': VIEW_GRAPH_CALIBRATOR_OPTIONS['max_num_iterations']},
+            )
+            optimized_focals[variable_cam_id] = float(scipy_result.x)
+            print(
+                'SciPy minimize_scalar report:',
+                f'nfev={scipy_result.nfev}',
+                f'initial_cost={scalar_objective(initial_focal):.6e}',
+                f'final_cost={float(scipy_result.fun):.6e}',
+                f'success={bool(scipy_result.success)}',
+            )
+            success = bool(scipy_result.success)
+            if not success:
+                print('View graph calibration scalar solve did not converge cleanly')
+        else:
+            summary = pyceres.SolverSummary()
+            pyceres.solve(options, problem, summary)
+            print(summary.BriefReport())
+            success = getattr(summary, 'is_solution_usable', lambda: True)()
+            if not success:
+                print('View graph calibration solver failed to produce a usable solution')
+
     counter = 0
-    for idx, cam in enumerate(cameras):
-        focal = focals[idx]
-        if (focal / np.mean(cam.focal_length) < VIEW_GRAPH_CALIBRATOR_OPTIONS['thres_lower_ratio'] or 
-            focal / np.mean(cam.focal_length) > VIEW_GRAPH_CALIBRATOR_OPTIONS['thres_higher_ratio']):
+    for cam_id, parameter_block in parameter_blocks.items():
+        focal = float(parameter_block[0])
+        focal_ratio = focal / initial_focals[cam_id]
+        if (
+            focal_ratio < VIEW_GRAPH_CALIBRATOR_OPTIONS['thres_lower_ratio']
+            or focal_ratio > VIEW_GRAPH_CALIBRATOR_OPTIONS['thres_higher_ratio']
+        ):
+            optimized_focals[cam_id] = initial_focals[cam_id]
             counter += 1
-            continue
-        cam.has_refined_focal_length = True
-        cam.focal_length = np.array([focal, focal])
-    
+        else:
+            optimized_focals[cam_id] = focal
+
+    for idx, cam in enumerate(cameras):
+        focal = float(optimized_focals[idx])
+        cam.focal_length = np.array([focal, focal], dtype=np.float64)
+        cam.has_prior_focal_length = True
+
     print(f'{counter} cameras are rejected in view graph calibration')
 
-    # Filter Image Pairs
-    eval_options = pyceres.EvaluateOptions()
-    eval_options.apply_loss_function = False
-    residuals = problem.evaluate_residuals(eval_options)
+    calibration_errors_sq = {}
     invalid_counter = 0
     thres_two_view_error_sq = VIEW_GRAPH_CALIBRATOR_OPTIONS['thres_two_view_error'] ** 2
 
-    # manually calculate the residuals
-    for idx, (pair_id, image_pair) in enumerate(valid_image_pairs.items()):
-        residual = residuals[2 * idx:2 * idx + 2]
-        if residual[0]**2 + residual[1]**2 > thres_two_view_error_sq:
+    for calibration_input in calibration_inputs:
+        error_sq = _compute_pair_error_sq(
+            calibration_input,
+            optimized_focals[calibration_input.camera_id1],
+            optimized_focals[calibration_input.camera_id2],
+        )
+        calibration_errors_sq[calibration_input.pair_id] = error_sq
+
+        image_pair = view_graph.image_pairs[calibration_input.pair_id]
+        image_pair.F = calibration_input.F
+        if error_sq > thres_two_view_error_sq:
             invalid_counter += 1
             image_pair.is_valid = False
-            view_graph.image_pairs[pair_id].is_valid = False
-    print(f'invalid / total number of two view geometry: {invalid_counter} / {len(valid_image_pairs)}')
+            image_pair.config = ConfigurationType.DEGENERATE
+        else:
+            image_pair.is_valid = True
+            image_pair.config = ConfigurationType.CALIBRATED
+            image1 = images[image_pair.image_id1]
+            image2 = images[image_pair.image_id2]
+            image_pair.E = _essential_from_fundamental(
+                image_pair.F,
+                cameras[image1.cam_id],
+                cameras[image2.cam_id],
+            )
+
+    print(f'invalid / total number of two view geometry: {invalid_counter} / {len(calibration_inputs)}')
+
+    raw_loss, robust_loss = EvaluateViewGraphCalibrationObjective(
+        calibration_inputs,
+        cameras,
+        VIEW_GRAPH_CALIBRATOR_OPTIONS['thres_loss_function'],
+    )
+    return ViewGraphCalibrationResult(
+        success=success,
+        initial_focals=initial_focals,
+        optimized_focals=optimized_focals.copy(),
+        calibration_errors_sq=calibration_errors_sq,
+        num_rejected_cameras=counter,
+        num_invalid_pairs=invalid_counter,
+        raw_loss=raw_loss,
+        robust_loss=robust_loss,
+    )
+
 
 class TorchVGC():
     def __init__(self, device='cuda:0'):

--- a/instantsfm/processors/view_graph_calibration.py
+++ b/instantsfm/processors/view_graph_calibration.py
@@ -10,12 +10,7 @@ import tqdm
 from scipy.optimize import minimize_scalar
 
 from instantsfm.scene.defs import ConfigurationType, ViewGraph
-from instantsfm.utils.cost_function import (
-    FetzerFocalLengthCostFunction,
-    FetzerFocalLengthSameCameraCostFunction,
-    fetzer_cost,
-    fetzer_ds,
-)
+from instantsfm.utils.cost_function import FetzerFocalLengthCostFunction, FetzerFocalLengthSameCameraCostFunction, fetzer_ds, fetzer_cost
 from instantsfm.utils.optimization_models import FetzerCalibrationModel
 
 # used by torch LM
@@ -196,22 +191,11 @@ def SolveViewGraphCalibration(view_graph: ViewGraph, cameras, images, VIEW_GRAPH
         parameter_blocks.setdefault(cam_id2, optimized_focals[cam_id2:cam_id2 + 1])
 
         if cam_id1 == cam_id2:
-            cost_function = FetzerFocalLengthSameCameraCostFunction(
-                calibration_input.F,
-                cameras[cam_id1].principal_point,
-            )
+            cost_function = FetzerFocalLengthSameCameraCostFunction(calibration_input.F, cameras[cam_id1].principal_point)
             problem.add_residual_block(cost_function, loss_function, [parameter_blocks[cam_id1]])
         else:
-            cost_function = FetzerFocalLengthCostFunction(
-                calibration_input.F,
-                cameras[cam_id1].principal_point,
-                cameras[cam_id2].principal_point,
-            )
-            problem.add_residual_block(
-                cost_function,
-                loss_function,
-                [parameter_blocks[cam_id1], parameter_blocks[cam_id2]],
-            )
+            cost_function = FetzerFocalLengthCostFunction(calibration_input.F, cameras[cam_id1].principal_point, cameras[cam_id2].principal_point)
+            problem.add_residual_block(cost_function, loss_function, [parameter_blocks[cam_id1], parameter_blocks[cam_id2]])
 
     num_variable_cameras = 0
     for cam_id, parameter_block in parameter_blocks.items():

--- a/tests/test_colmap_eval_utils.py
+++ b/tests/test_colmap_eval_utils.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+
+import numpy as np
+
+from instantsfm.eval.colmap_eval.evaluation.utils import (
+    compute_abs_errors,
+    compute_rel_errors,
+)
+
+if not hasattr(np, "acos"):
+    np.acos = np.arccos  # type: ignore[attr-defined]
+
+
+class _FakeRotation:
+    def __init__(self, angle_rad: float):
+        self._angle_rad = angle_rad
+
+    def angle(self) -> float:
+        return self._angle_rad
+
+
+class _FakeTransform:
+    def __init__(self, translation, angle_rad: float = 0.0):
+        self.translation = np.array(translation, dtype=np.float64)
+        self._angle_rad = angle_rad
+        self.rotation = _FakeRotation(angle_rad)
+
+    def inverse(self) -> "_FakeTransform":
+        return _FakeTransform(-self.translation, -self._angle_rad)
+
+    def __mul__(self, other: "_FakeTransform") -> "_FakeTransform":
+        return _FakeTransform(
+            self.translation + other.translation,
+            self._angle_rad + other._angle_rad,
+        )
+
+
+class _MethodImage:
+    def __init__(self, image_id: int, name: str, transform: _FakeTransform):
+        self.image_id = image_id
+        self.name = name
+        self._transform = transform
+
+    def cam_from_world(self) -> _FakeTransform:
+        return self._transform
+
+
+class _PropertyImage:
+    def __init__(self, image_id: int, name: str, transform: _FakeTransform):
+        self.image_id = image_id
+        self.name = name
+        self.cam_from_world = transform
+
+
+class _FakeReconstruction:
+    def __init__(self, images):
+        self.images = OrderedDict((image.image_id, image) for image in images)
+
+    def num_images(self) -> int:
+        return len(self.images)
+
+
+def test_compute_abs_errors_accepts_method_cam_from_world():
+    transform = _FakeTransform([1.0, 2.0, 3.0], angle_rad=0.25)
+    sparse_gt = _FakeReconstruction([_MethodImage(1, "im1.jpg", transform)])
+    sparse = _FakeReconstruction([_MethodImage(1, "im1.jpg", transform)])
+
+    dts, dRs = compute_abs_errors(sparse_gt, sparse)
+
+    assert np.array_equal(dts, np.array([0.0]))
+    assert np.array_equal(dRs, np.array([0.0]))
+
+
+def test_compute_rel_errors_accepts_method_and_property_cam_from_world():
+    gt_images = [
+        _MethodImage(1, "gt/im1.jpg", _FakeTransform([0.0, 0.0, 0.0])),
+        _MethodImage(2, "gt/im2.jpg", _FakeTransform([1.0, 0.0, 0.0])),
+    ]
+    sparse_images = [
+        _PropertyImage(1, "pred/im1.jpg", _FakeTransform([0.0, 0.0, 0.0])),
+        _PropertyImage(2, "pred/im2.jpg", _FakeTransform([1.0, 0.0, 0.0])),
+    ]
+    sparse_gt = _FakeReconstruction(gt_images)
+    sparse = _FakeReconstruction(sparse_images)
+
+    dts, dRs = compute_rel_errors(
+        sparse_gt,
+        sparse,
+        min_proj_center_dist=1e-6,
+    )
+
+    assert np.array_equal(dts, np.array([0.0, 0.0]))
+    assert np.array_equal(dRs, np.array([0.0, 0.0]))

--- a/tests/test_view_graph_calibration.py
+++ b/tests/test_view_graph_calibration.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import csv
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest
+
+from instantsfm.controllers.config import Config
+from instantsfm.controllers.data_reader import ReadColmapDatabase
+from instantsfm.processors.view_graph_calibration import (
+    BuildViewGraphCalibrationInputs,
+    EvaluateViewGraphCalibrationObjective,
+    SolveViewGraphCalibration,
+)
+from instantsfm.processors.view_graph_manipulation import DecomposeRelPose, UpdateImagePairsConfig
+
+
+ETH3D_DB_ROOT = ROOT / "db" / "eth3d" / "dslr"
+ETH3D_DATASET_ROOT = ROOT / "datasets" / "eth3d" / "dslr"
+STATUS_TSV = ROOT / "db" / "eth3d_dslr_feature_matching_status.tsv"
+COLMAP_BIN = shutil.which("colmap")
+REL_TOL = 2e-2
+ABS_TOL = 1e-8
+
+
+@lru_cache(maxsize=1)
+def _load_eth3d_eval_module():
+    spec = importlib.util.spec_from_file_location(
+        "instantsfm_eth3d_eval",
+        ROOT / "tools" / "eval_eth3d_pose_auc.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@lru_cache(maxsize=1)
+def _discover_scenes() -> tuple[str, ...]:
+    env_scenes = os.environ.get("INSTANTSFM_ETH3D_SCENES", "").strip()
+    if env_scenes:
+        return tuple(scene.strip() for scene in env_scenes.split(",") if scene.strip())
+
+    scenes = []
+    with STATUS_TSV.open() as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            if row["status"] in ("ok", "skipped"):
+                scenes.append(row["scene"])
+    return tuple(scenes)
+
+
+
+def _prepare_scene_dir(tmp_path: Path, scene: str, scheme: str) -> Path:
+    scene_dir = tmp_path / scheme / scene
+    scene_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(ETH3D_DB_ROOT / scene / "database.db", scene_dir / "database.db")
+
+    images_link = scene_dir / "images"
+    if not images_link.exists():
+        images_link.symlink_to(ETH3D_DATASET_ROOT / scene / "images")
+
+    calib_link = scene_dir / "dslr_calibration_undistorted"
+    if not calib_link.exists():
+        calib_link.symlink_to(ETH3D_DATASET_ROOT / scene / "dslr_calibration_undistorted")
+
+    if scheme == "gt_intrinsics":
+        eth3d_eval = _load_eth3d_eval_module()
+        _, ok, message = eth3d_eval.inject_gt_intrinsics_for_scene(scene_dir, force_reinject=False)
+        assert ok, message
+
+    return scene_dir
+
+
+
+def _load_prepared_problem(scene_dir: Path):
+    view_graph, cameras, images, feature_name, _ = ReadColmapDatabase(str(scene_dir / "database.db"))
+    UpdateImagePairsConfig(view_graph, cameras, images)
+    DecomposeRelPose(view_graph, cameras, images)
+    config = Config(feature_name)
+    calibration_inputs = BuildViewGraphCalibrationInputs(view_graph, cameras, images)
+    return view_graph, cameras, images, config, calibration_inputs
+
+
+
+def _run_colmap_view_graph_calibrator(database_path: Path, config: Config):
+    assert COLMAP_BIN is not None
+    options = config.VIEW_GRAPH_CALIBRATOR_OPTIONS
+    cmd = [
+        COLMAP_BIN,
+        "view_graph_calibrator",
+        "--database_path",
+        str(database_path),
+        "--cross_validate_prior_focal_lengths",
+        "1",
+        "--min_calibrated_pair_ratio",
+        "0.5",
+        "--reestimate_relative_pose",
+        "0",
+        "--min_focal_length_ratio",
+        str(options["thres_lower_ratio"]),
+        "--max_focal_length_ratio",
+        str(options["thres_higher_ratio"]),
+        "--max_calibration_error",
+        str(options["thres_two_view_error"]),
+        "--default_random_seed",
+        "0",
+    ]
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False)
+    assert proc.returncode == 0, proc.stdout
+
+
+
+def _evaluate_colmap_loss(database_path: Path, calibration_inputs, config: Config):
+    _, cameras, _, _, _ = ReadColmapDatabase(str(database_path))
+    return EvaluateViewGraphCalibrationObjective(
+        calibration_inputs,
+        cameras,
+        config.VIEW_GRAPH_CALIBRATOR_OPTIONS["thres_loss_function"],
+    )
+
+
+
+def _assert_not_worse_than_colmap(tmp_path: Path, scheme: str):
+    failures = []
+    for scene in _discover_scenes():
+        scene_dir = _prepare_scene_dir(tmp_path, scene, scheme)
+        view_graph, cameras, images, config, calibration_inputs = _load_prepared_problem(scene_dir)
+
+        instant_result = SolveViewGraphCalibration(
+            view_graph,
+            cameras,
+            images,
+            config.VIEW_GRAPH_CALIBRATOR_OPTIONS,
+        )
+
+        colmap_db_path = scene_dir / "database_colmap.db"
+        shutil.copy2(scene_dir / "database.db", colmap_db_path)
+        _run_colmap_view_graph_calibrator(colmap_db_path, config)
+        colmap_raw_loss, colmap_robust_loss = _evaluate_colmap_loss(
+            colmap_db_path,
+            calibration_inputs,
+            config,
+        )
+
+        tolerance = max(ABS_TOL, REL_TOL * max(abs(colmap_robust_loss), 1.0))
+        if instant_result.robust_loss > colmap_robust_loss + tolerance:
+            failures.append(
+                (
+                    scene,
+                    instant_result.robust_loss,
+                    colmap_robust_loss,
+                    instant_result.raw_loss,
+                    colmap_raw_loss,
+                )
+            )
+
+    assert not failures, "\n".join(
+        f"{scene}: instant robust={instant_robust:.12f}, colmap robust={colmap_robust:.12f}, "
+        f"instant raw={instant_raw:.12f}, colmap raw={colmap_raw:.12f}"
+        for scene, instant_robust, colmap_robust, instant_raw, colmap_raw in failures
+    )
+
+
+@pytest.mark.skipif(COLMAP_BIN is None, reason="colmap executable is required for ETH3D view-graph calibration regression tests")
+def test_view_graph_calibration_eth3d_no_intrinsics_not_worse_than_colmap(tmp_path):
+    _assert_not_worse_than_colmap(tmp_path, "no_intrinsics")
+
+
+@pytest.mark.skipif(COLMAP_BIN is None, reason="colmap executable is required for ETH3D view-graph calibration regression tests")
+def test_view_graph_calibration_eth3d_gt_intrinsics_not_worse_than_colmap(tmp_path):
+    _assert_not_worse_than_colmap(tmp_path, "gt_intrinsics")
+
+
+@pytest.mark.skipif(COLMAP_BIN is None, reason="colmap executable is required for ETH3D view-graph calibration regression tests")
+def test_view_graph_calibration_gt_intrinsics_keeps_prior_focals_fixed(tmp_path):
+    drifted_scenes = []
+    for scene in _discover_scenes():
+        scene_dir = _prepare_scene_dir(tmp_path, scene, "gt_intrinsics")
+        view_graph, cameras, images, config, _ = _load_prepared_problem(scene_dir)
+        initial_focals = [float(cam.focal()) for cam in cameras]
+        result = SolveViewGraphCalibration(
+            view_graph,
+            cameras,
+            images,
+            config.VIEW_GRAPH_CALIBRATOR_OPTIONS,
+        )
+        if not all(abs(a - b) <= ABS_TOL for a, b in zip(initial_focals, result.optimized_focals)):
+            drifted_scenes.append((scene, initial_focals, result.optimized_focals.tolist()))
+
+    assert not drifted_scenes, "\n".join(
+        f"{scene}: initial={initial}, optimized={optimized}"
+        for scene, initial, optimized in drifted_scenes
+    )


### PR DESCRIPTION
Found likely bugs in InstantSfM’s view-graph calibration vs glomap/COLMAP:

  - It optimized cameras that already had has_prior_focal_length=True; glomap keeps those fixed.
  - It didn’t write calibrated state back like glomap:
      - cameras weren’t promoted to has_prior_focal_length=True
      - good pairs weren’t promoted to CALIBRATED
      - bad pairs weren’t marked DEGENERATE
      - E wasn’t recomputed from the refined calibration
  - It filtered pair validity using unreverted degenerate focal solutions.
  - It didn’t recompute fundamental from Essential for already-calibrated pairs before optimization.
  - On ETH3D single-camera scenes, the same-camera optimization path converged worse than COLMAP; Use an exact bounded scalar solve against the same robust loss.
 
  What was added:
 
 
  - glomap-style calibration input preparation
  - exact loss evaluation helpers
  - prior-focal fixing behavior
  - rejected-camera rollback before pair filtering
  - calibrated/degenerate state updates
  - ETH3D regression tests for:
      - `no-intrinsics loss` vs `colmap view_graph_calibrator`
      - `gt-intrinsics loss` vs `colmap view_graph_calibrator`
      - `gt-intrinsics` prior focal no-drift
 
 
  Verification run:
 
 
  - `PYTHONPATH=/workspaces/InstantSfM INSTANTSFM_ETH3D_SCENES=botanical_garden,bridge,courtyard,facade,terrains pytest -q tests/test_view_graph_calibration.py -q`